### PR TITLE
Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9|^3.0",


### PR DESCRIPTION
Adds `^13.0` to the illuminate/contracts constraint so the package installs on Laravel 13. Constraint-only change — no source changes; nothing in this package touches API that changed between Laravel 12 and 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)